### PR TITLE
Allow the specification of custom endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ ec2.DescribeInstances(function(err, data) {
 });
 ```
 
+## Support for third party services supporting AWS EC2 API
+
+Support for third party services supporting AWS EC2 API requires version greater than 1.4.0
+
+```
+dependencies : {
+    "awssum-amazon-ec2" : "> 1.4.0",
+},
+```
+
+### Example ##
+
+```
+var amazonEc2 = require('awssum-amazon-ec2');
+
+var ec2 = new amazonEc2.Ec2({
+    'accessKeyId'     : process.env.ACCESS_KEY_ID,
+    'secretAccessKey' : process.env.SECRET_ACCESS_KEY,
+    'region'          : 'myregion',
+    'endPoint'        : { 'region' : 'myregion',
+                          'endpoint' : {'protocol' : 'http', 'host' : 'localhost', 'port' : 8123, 'path' : '/path/to/service'}
+                        }
+});
+```
+
 ## Operations ##
 
 ### AllocateAddress ###

--- a/awssum-amazon-ec2.js
+++ b/awssum-amazon-ec2.js
@@ -48,6 +48,18 @@ var version = '2013-08-15';
 var Ec2 = function(opts) {
     var self = this;
 
+    if (! _.isEmpty(opts.endPoint) ) {
+      if (_.isObject(opts.endPoint)) {
+          if (!  opts.endPoint.region) {
+              throw MARK + "region not defined";
+          }
+          if (!  opts.endPoint.endpoint.host) {
+              throw MARK + "host not defined for region'"+ opts.endPoint.region +"'";
+          }
+          endPoint[opts.endPoint.region] = opts.endPoint.endpoint;
+      }
+    }
+
     // call the superclass for initialisation
     Ec2.super_.call(this, opts);
 
@@ -65,8 +77,21 @@ util.inherits(Ec2, amazon.AmazonSignatureV2);
 // --------------------------------------------------------------------------------------------------------------------
 // methods we need to implement from awssum.js/amazon.js
 
+Ec2.prototype.protocol = function() {
+    return endPoint[this.region()].protocol || "https";
+};
+
 Ec2.prototype.host = function() {
-    return endPoint[this.region()];
+    return endPoint[this.region()].host || endPoint[this.region()];
+};
+
+Ec2.prototype.port = function() {
+    var self = this;
+    return endPoint[this.region()].port || ((self.protocol() === 'http') ? 80 :  443);
+};
+
+Ec2.prototype.path = function() {
+    return endPoint[this.region()].path || "/";
 };
 
 Ec2.prototype.version = function() {

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -1,0 +1,46 @@
+// --------------------------------------------------------------------------------------------------------------------
+//
+// require.js
+//
+// Written by Andrew Chilton <andychilton@gmail.com>
+//
+// License: http://opensource.org/licenses/MIT
+//
+// --------------------------------------------------------------------------------------------------------------------
+// requires
+
+var fs = require('fs');
+var test = require('tape');
+
+// local
+var amazonEc2 = require('../awssum-amazon-ec2.js');
+var Ec2 = amazonEc2.Ec2;
+
+var FAKE_ACCESS_KEY_ID = 'WHATEVER';
+var FAKE_SECRET_ACCESS_KEY = 'WHATEVER';
+// --------------------------------------------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------------------------------------------
+
+test('Custom endpoint', function(t) {
+
+    var ec2 = new Ec2({
+        'accessKeyId'     : FAKE_ACCESS_KEY_ID,
+        'secretAccessKey' : FAKE_SECRET_ACCESS_KEY,
+        'region'          : 'myregion',
+        'endPoint'        : { 'region' : 'myregion',
+                              'endpoint' : {'protocol' : 'http', 'host' : 'localhost', 'port' : 8123, 'path' : '/path/to/service'}
+                            }
+    });
+
+    t.ok(ec2, 'Ec2 instance created');
+    t.equal('myregion', ec2.region(), 'Region set');
+    t.equal('http', ec2.protocol(), 'Endpoint protocol set');
+    t.equal('localhost', ec2.host(), 'Endpoint host set');
+    t.equal(8123, ec2.port(), 'Endpoint port set');
+    t.equal('/path/to/service', ec2.path(), 'Endpoint path set');
+
+    t.end();
+});
+
+// --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

This one allows the specification of a custom endpoint to talk to. See the changes in README for an example. 

I wrote it in order to use awssum libraries against third party services supporting the AWS EC2 API, like OpenStack, Eucalyptus etc. I am using it successfully with OpenStack as well as Amazon EC2.

It comes together with pull requests for awssum and awssum-amazon.  Support for awssum-amazon-s3 will follow soon.

Please review them and consider rolling them into the main distribution.

Thanks,
Giannis
